### PR TITLE
Re-add missing dependency "express"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       "@ionic-native/splash-screen": "^5.36.0",
       "@ionic-native/status-bar": "^5.36.0",
       "@ionic/angular": "^6.0.0",
+      "express": "^4.17.2",
       "rxjs": "~6.6.0",
       "simple-keyboard": "^3.4.46",
       "spotify-web-api-js": "^1.5.2",


### PR DESCRIPTION
Dependency was removed by previous commit (cacdcd1ee7b819f2efc7bf818b22f2786a191a31), but is required