### PR TITLE
Support https connection to node-sonos-http-api-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Now the user interface should appear
     "node-sonos-http-api": {
         "server": "127.0.0.1",
         "port": "5005",
+        "useHttps": false,
         "rooms": [
             "Livingroom",
             "Kitchen"
@@ -100,6 +101,7 @@ Now the user interface should appear
 }
 ```
 Point the node-sonos-http-api section to the adress and the port where the service is running.
+UseHttps can be used to specify whether the specified address and port expects an https connection or not. 
 The rooms are the Sonos room names that you want to be allowed as target.
 
 Room selection isn't implemented yet, so only the first room will be used at the moment.

--- a/src/app/player.service.ts
+++ b/src/app/player.service.ts
@@ -116,7 +116,13 @@ export class PlayerService {
 
   private sendRequest(url: string) {
     this.getConfig().subscribe(config => {
-      const baseUrl = 'http://' + config.server + ':' + config.port + '/' + config.rooms[0] + '/';
+
+      let protocol = "http";
+      if(config.useHttps === true) {
+          protocol = "https";
+      }
+
+      const baseUrl = protocol + '://' + config.server + ':' + config.port + '/' + config.rooms[0] + '/';
       this.http.get(baseUrl + url).subscribe();
     });
   }

--- a/src/app/sonos-api.ts
+++ b/src/app/sonos-api.ts
@@ -1,6 +1,7 @@
 export interface SonosApiConfig {
     server: string;
     port: string;
+    useHttps?: boolean;
     rooms: string[];
     tts?: {
         enabled?: boolean;


### PR DESCRIPTION
Adds the option to support https connections to node-sonos-http-api-server
Adds the option to choose if the connection to node-sonos-http-api-server is http or https