### PR TITLE
When retrieving albums by artist id make sure to group them by the or…

### DIFF
--- a/src/app/spotify.service.ts
+++ b/src/app/spotify.service.ts
@@ -68,7 +68,7 @@ export class SpotifyService {
           return response.items.map(item => {
             const media: Media = {
               id: item.id,
-              artist: item.artists[0].name,
+              artist: item.artists.find(value => value.id === id).name,
               title: item.name,
               cover: item.images[0].url,
               type: 'spotify',

--- a/src/app/spotify.ts
+++ b/src/app/spotify.ts
@@ -5,6 +5,7 @@ export interface SpotifyAlbumsResponseImage {
 
 export interface SpotifyAlbumsResponseArtist {
     name: string;
+    id: string;
 }
 
 export interface SpotifyAlbumsResponseItem {


### PR DESCRIPTION
…iginally requested artist id and not the first one

Some albums have multiple artists and the current code would alwayst just pick the first one but that is not guaranteed to be the one we just searched for.
By definition the original artist must be in the artists list thoug, so we search for it and take its name (this could be optimized).

This has helped us unclutter the interface a lot.