### PR TITLE
Fixed ion-popover not being displayed

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -74,3 +74,7 @@ ion-toolbar {
 .alert-message {
     font-size: 18px !important;
 }
+
+ion-popover [popover]:not(:popover-open):not(dialog[open]) {
+    display: contents;
+}


### PR DESCRIPTION
Drop downs stopped working after recent browser updates (Chrome, Opera, ...). Seems to be a problem with ionic.

Found this fix here:
https://stackoverflow.com/a/76381282